### PR TITLE
Execute GH Actions in parallel

### DIFF
--- a/.github/workflows/pdk-validate.yml
+++ b/.github/workflows/pdk-validate.yml
@@ -15,38 +15,40 @@ permissions:
 
 
 jobs:
-  pdk-validate:
-    name: Run PDK validation check
+  pdk-valiation:
+    name: Run PDK validation checks on supported Puppet versions
+    strategy:
+      matrix:
+        version: [6, 7]
     runs-on: ubuntu-latest
+    container:
+      image: puppet/pdk:latest
     env:
       PATH: /opt/puppetlabs/pdk/bin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Install the PDK
-        run: |
-          wget https://apt.puppet.com/puppet-tools-release-bionic.deb
-          sudo dpkg -i puppet-tools-release-bionic.deb
-          sudo apt-get update
-          sudo apt-get install pdk
-
-      - name: PDK Validation - Version 6
+      - name: PDK Validation
         run: |
           cd $GITHUB_WORKSPACE
-          pdk validate --puppet-version=6
+          pdk validate --puppet-version=${{ matrix. version }}
 
-      - name: PDK Validation - Version 7
+  pdk-unit-testing:
+    name: Run PDK unit testing on supported Puppet versions
+    strategy:
+      matrix:
+        version: [6, 7]
+    runs-on: ubuntu-latest
+    container:
+      image: puppet/pdk:latest
+    env:
+      PATH: /opt/puppetlabs/pdk/bin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: PDK Unit Testing
         run: |
           cd $GITHUB_WORKSPACE
-          pdk validate --puppet-version=7
-
-      - name: PDK Unit Testing - Version 6
-        run: |
-          cd $GITHUB_WORKSPACE
-          pdk test unit --puppet-version=6
-
-      - name: PDK Unit Testing - Version 7
-        run: |
-          cd $GITHUB_WORKSPACE
-          pdk test unit --puppet-version=7
+          pdk test unit --puppet-version=${{ matrix.version }}


### PR DESCRIPTION
PROBLEM:

The GitHub Actions for syntax validation/linting/unit testing all happen
sequentially, instead of in parallel. They should run in parallel so
tests don't take so long.

SOLUTION:

Instead of installing the `pdk` within a runner, use a Docker container
from Puppet that already has the `pdk` installed that way all tests can
be run in parallel.

OUTCOME:

GH Actions run in parallel and PR testing happens much more quickly.
